### PR TITLE
Update "main" field to point to root index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "conditional-helpers",
-  "version": "2.0.1",
+  "version": "2.0.3",
   "description": "A collection of JavaScript helper functions to be used in conditional logic within projects",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "jest",
     "lint": "eslint .",


### PR DESCRIPTION
Resolved deprecation warning caused by incorrect "main" field referencing dist/index.js. Adjusted to correctly reference root-level index.js, ensuring compatibility with ES module resolution.